### PR TITLE
Add bundle manifest entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ License EPL v2.0
 [![TravisCI Build Status](https://travis-ci.org/digitaldan/harmony-client.svg?branch=master)](https://travis-ci.org/digitaldan/harmony-client)
 # Running
 
-mvn clean compile assembly:single
+`mvn clean compile assembly:single`
  
-java -cp target/harmony-client-1.0-SNAPSHOT-jar-with-dependencies.jar com.digitaldan.harmony.App YOUR_HUB_IP
+`java -cp target/harmony-client-*-jar-with-dependencies.jar com.digitaldan.harmony.shell.App YOUR_HUB_IP`
  
 This will launch a interactive shell, commands are:
  

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,16 @@
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+Bundle-ContactAddress: ${project.url}
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+
+Import-Package:\
+    !com.martiansoftware.jsap,\
+    !org.kohsuke.*,\
+    *
+
+-removeheaders: Private-Package
+
+-exportcontents:\
+    com.digitaldan.harmony,\
+    com.digitaldan.harmony.config

--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,56 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-        <groupId>com.github.digitaldan</groupId>
+	<groupId>com.github.digitaldan</groupId>
 	<artifactId>harmony-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.2</version>
-	<name>harmony-client</name>
+	<version>1.1.3</version>
+	<name>Harmony Client</name>
+	<description>Logitech Harmony WebSocket Client</description>
 	<url>https://github.com/digitaldan/harmony-client</url>
 	<properties>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 	</properties>
 	<distributionManagement>
-                <snapshotRepository>
-                        <id>ossrh</id>
-                        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                        <id>ossrh</id>
-                        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-        </distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>4.2.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>com.digitaldan.harmony.App</mainClass>
+							<mainClass>com.digitaldan.harmony.shell.App</mainClass>
 						</manifest>
 					</archive>
 					<descriptorRefs>

--- a/src/main/java/com/digitaldan/harmony/shell/App.java
+++ b/src/main/java/com/digitaldan/harmony/shell/App.java
@@ -1,4 +1,4 @@
-package com.digitaldan.harmony;
+package com.digitaldan.harmony.shell;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -13,10 +13,11 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.digitaldan.harmony.HarmonyClient;
+import com.digitaldan.harmony.HarmonyClientListener;
 import com.digitaldan.harmony.config.Activity;
 import com.digitaldan.harmony.config.Activity.Status;
 import com.digitaldan.harmony.config.HarmonyConfig;
-import com.digitaldan.harmony.shell.ShellCommandWrapper;
 import com.martiansoftware.jsap.CommandLineTokenizer;
 
 /**


### PR DESCRIPTION
This PR adds bundle manifest entries so the library can be easily used as an OSGi bundle with openHAB. 

I don't think the shell package will be very useful in an OSGi context so I've removed it from the exports and also moved the `App` class into that package. That way there's also no need for importing the extra libraries consumed by the shell classes.

Can you also publish the library on Bintray JCenter or Maven Central? That way it can be easily consumed and we no longer have to store it in the openhab2-addons GitHub repo. Then we can create a follow up PR that looks like [this](https://github.com/openhab/openhab2-addons/compare/master...wborn:harmony-dependency?expand=1). :-)

Below follows some output of using the library bundle with openHAB:

```
openhab> bundle:list
...
215 │ Active │  80 │ 1.1.3                 │ Harmony Client
216 │ Active │  80 │ 2.5.0.201903280041    │ openHAB Add-ons :: Bundles :: HarmonyHub Binding


openhab> bundle:requirements 215
com.github.digitaldan.harmony-client_1.1.3 [215] requires:
----------------------------------------------------------
osgi.wiring.package; (&(osgi.wiring.package=com.google.gson)(&(version>=2.8.0)(!(version>=3.0.0)))) resolved by:
   osgi.wiring.package; com.google.gson 2.8.2 from com.google.gson_2.8.2.v20180104-1110 [21]
osgi.wiring.package; (&(osgi.wiring.package=com.google.gson.annotations)(&(version>=2.8.0)(!(version>=3.0.0)))) resolved by:
   osgi.wiring.package; com.google.gson.annotations 2.8.2 from com.google.gson_2.8.2.v20180104-1110 [21]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.client)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.client 9.4.12 from org.eclipse.jetty.client_9.4.12.v20180830 [76]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.client.api)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.client.api 9.4.12 from org.eclipse.jetty.client_9.4.12.v20180830 [76]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.client.util)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.client.util 9.4.12 from org.eclipse.jetty.client_9.4.12.v20180830 [76]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.http)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.http 9.4.12 from org.eclipse.jetty.http_9.4.12.v20180830 [80]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.websocket.api)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.websocket.api 9.4.12 from org.eclipse.jetty.websocket.api_9.4.12.v20180830 [96]
osgi.wiring.package; (&(osgi.wiring.package=org.eclipse.jetty.websocket.client)(&(version>=9.4.0)(!(version>=10.0.0)))) resolved by:
   osgi.wiring.package; org.eclipse.jetty.websocket.client 9.4.12 from org.eclipse.jetty.websocket.client_9.4.12.v20180830 [97]
osgi.wiring.package; (&(osgi.wiring.package=org.slf4j)(&(version>=1.7.0)(!(version>=2.0.0)))) resolved by:
   osgi.wiring.package; org.slf4j 1.7.25 from org.ops4j.pax.logging.pax-logging-api_1.10.1 [6]
osgi.ee; (&(osgi.ee=JavaSE)(version=1.8)) resolved by:
   osgi.ee; JavaSE [1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0] from org.eclipse.osgi_3.12.100.v20180210-1608 [0]
osgi.ee; (&(osgi.ee=JavaSE)(version=1.8)) resolved by:
   osgi.ee; JavaSE [1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0] from org.eclipse.osgi_3.12.100.v20180210-1608 [0]


openhab> bundle:capabilities 215
com.github.digitaldan.harmony-client_1.1.3 [215] provides:
----------------------------------------------------------
osgi.wiring.bundle; com.github.digitaldan.harmony-client 1.1.3 [UNUSED]
osgi.wiring.host; com.github.digitaldan.harmony-client 1.1.3 [UNUSED]
osgi.identity; com.github.digitaldan.harmony-client 1.1.3 [UNUSED]
osgi.wiring.package; com.digitaldan.harmony 1.1.3 required by:
   org.openhab.binding.harmonyhub_2.5.0.201903280041 [216]
osgi.wiring.package; com.digitaldan.harmony.config 1.1.3 required by:
   org.openhab.binding.harmonyhub_2.5.0.201903280041 [216]
```